### PR TITLE
disable keyboard interaction to prevent conflict with canvas

### DIFF
--- a/src/LibBlockly.js
+++ b/src/LibBlockly.js
@@ -10,6 +10,7 @@ export class LibBlocky {
             console.log(`[${LibBlocky.name()}] Initialising...`);
             this._registerHooks();
             this._registerSettings();
+            Blockly.ShortcutRegistry.registry.reset();
             this._toolbox = options?.toolbox;
             this._editors = {};
             game.modules.get(LibBlocky.ID()).instance = this;


### PR DESCRIPTION
* fix #6 
This temporary fix disable keyboard interaction inside Blockly editor to prevent side-effects on canvas. Keybindings will be added later as a better solution.